### PR TITLE
Update READMEs for accuracy and completeness

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ A work-in-progress remote media control system that enables to browse and contro
 ## Overview
 
 MPV Remote Play consists of two main components:
-- **Server** - A Bun.js backend that manages MPV player instances and serves media from configured shares
-- **Mobile App** - An Expo React Native app for browsing media files and controlling remote MPV sessions
+- **Server** (`/mpv-remote-server`) - A Python/FastAPI backend that manages MPV player instances and serves media from configured shares.
+- **Mobile App** (`/expo-app`) - An Expo React Native app for browsing media files and controlling remote MPV sessions.
 
 The system allows you to:
 - Browse media libraries from your phone
@@ -20,8 +20,8 @@ The system allows you to:
 
 ## Architecture
 
-### Server (`/server`)
-Built with Bun.js runtime, the server provides:
+### Server (`/mpv-remote-server`)
+Built with Python using the FastAPI framework, the server provides:
 
 **Core Services:**
 - **MPV Manager** - Creates and controls MPV instances via Windows named pipe IPC
@@ -45,30 +45,61 @@ Expo React Native application
 **Tech Stack:**
 - Expo 53 with file-based routing
 
+### Structure
+Key directories within `expo-app/src/`:
+- `src/app`: Handles navigation and routing within the app, using file-system based routing.
+- `src/components`: Contains reusable UI components used throughout the application.
+- `src/hooks`: Stores custom React hooks for shared logic and state management.
+- `src/lib`: Includes utility functions, API integration logic, and other shared libraries.
+- `src/screens`: Contains the main screen components, representing different views of the app.
+- `src/store`: Manages global application state, potentially using Zustand or a similar state management library.
+
 ## Getting Started
 
 ### Prerequisites
-- **MPV player** - Must be installed and available in system PATH
-- **FFmpeg** - Required for thumbnail generation
-- **Bun.js** - Runtime for the server
-- **Node.js & npm** - For Expo development
+- **MPV player** - Must be installed and available in your system's PATH.
+- **FFmpeg** - Required for thumbnail generation by the server, must be in PATH.
+- **Python 3.10+** - Required for the server.
+- **`uv`** - Modern Python packaging tool (install via `pip install uv`). Used for server dependency management.
+- **Node.js & npm (or yarn)** - Required for Expo mobile app development.
+- **Expo CLI** (optional) - Useful for running the mobile app directly (e.g., `npm install -g expo-cli` then `expo start`). Can also use `npm start` from within `expo-app`.
 
 ### Server Setup
 ```bash
-cd server
-bun install
-bun run start
+cd mpv-remote-server
+# Install dependencies using uv (reads pyproject.toml)
+uv pip install .
+# Run the server (defaults to port 8000)
+uv run uvicorn main:app --reload
 ```
-Server runs on `http://localhost:3000`
+Server runs on `http://localhost:8000` (see `mpv-remote-server/README.md` for more details and port configuration options).
 
 **Configuration:**
-Edit `server/src/config.ts` to configure your media shares:
-```typescript
-export const MEDIA_SHARES = {
-  movies: "C:/Media/Movies",
-  shows: "D:/TV Shows",
-  music: "E:/Music"
-} as const
+Edit `mpv-remote-server/config.py` to set up your media shares. The server uses `pydantic-settings`, so you can also use environment variables (prefixed with `MPV_REMOTE_`) or a `.env` file.
+Example:
+```python
+# In mpv-remote-server/config.py
+from pathlib import Path
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+class Settings(BaseSettings):
+    media_shares: dict[str, str] = {
+        "movies": "C:/Path/To/Your/Movies",
+        "tv_shows": "/mnt/user/TV_Shows",
+        # Add more shares as needed (e.g., "anime": "D:/Anime")
+    }
+    # Other settings like media_extensions, thumbnails_dir, cache_file
+    # are also available, check the actual config.py for details.
+    # For example:
+    # media_extensions: set[str] = {".mp4", ".mkv", ".avi"}
+    # thumbnails_dir: Path = Path.cwd() / "thumbnails"
+
+    model_config = SettingsConfigDict(
+        env_file=".env", # Looks for a .env file
+        env_prefix="MPV_REMOTE_", # For environment variables
+    )
+
+settings = Settings()
 ```
 
 ### Mobile App Setup

--- a/mpv-remote-server/README.md
+++ b/mpv-remote-server/README.md
@@ -1,0 +1,102 @@
+```markdown
+# MPV Remote Server
+
+This server is a Python application built with FastAPI. It manages MPV player instances, serves media files from configured shares, and provides an API for a remote client (like the `expo-app`) to interact with.
+
+## Key Features
+
+- Control MPV instances (play, pause, stop, load files, etc.).
+- Browse media libraries from configured shares.
+- Automatic scanning of media shares for new files (via `services/scanner.py` triggered by `services/shares.py`).
+- Thumbnail generation for video files.
+- Real-time status updates for MPV instances.
+
+## Project Structure
+
+- **`main.py`**: The main FastAPI application file, defining API endpoints and application lifecycle events (startup/shutdown for share service).
+- **`config.py`**: Handles application settings, including media share paths, supported media extensions, thumbnail directory, and cache file location. Settings are loaded from environment variables or a `.env` file.
+- **`run.py`**: A utility script to start the development server using `uvicorn main:app --host 127.0.0.1 --port 8000 --reload`. The primary command for running the server is `uvicorn main:app`.
+- **`services/`**: Contains the core logic of the server:
+    - **`mpv_manager.py`**: Manages MPV player instances, including creation, termination, and command execution via IPC (Inter-Process Communication, likely using Windows named pipes as hinted in the main project README).
+    - **`shares.py`**: Handles the logic for accessing and managing media shares, including file listings, metadata, and initialization of the media scanner.
+    - **`scanner.py`**: Scans the configured media directories to discover and cache media files.
+    - **`thumbnails.py`**: Responsible for generating and caching thumbnails for video files using Pillow, likely after extraction with a tool like FFmpeg.
+    - **`cache.py`**: Provides caching mechanisms for media metadata and thumbnails (as suggested by `config.py`'s `cache_file` setting).
+- **`models/`**: Defines Pydantic models for data validation and serialization (e.g., API request/response bodies like `RemoteCommand`, `Track`).
+
+## API Endpoints
+
+The server exposes the following primary API endpoints (defined in `main.py`):
+
+- **GET `/api/status`**: Returns the current status of the server, timestamp, and media share statistics.
+- **GET `/api/instances`**: Lists all active MPV instances with their ID, status, last seen time, and client name.
+- **POST `/api/instances`**: Creates a new MPV instance. Can optionally take a `mediaFile` in the request body to start playback immediately. It may reuse an existing running instance.
+- **GET `/api/instances/{instance_id}`**: Retrieves details for a specific MPV instance.
+- **DELETE `/api/instances/{instance_id}`**: Stops and removes a specific MPV instance.
+- **POST `/api/instances/{instance_id}/command`**: Sends a command (defined by `RemoteCommand` model) to a specific MPV instance.
+- **GET `/api/instances/{instance_id}/tracks`**: Gets available audio and subtitle tracks, and current selections for the playing media in an instance.
+- **POST `/api/instances/{instance_id}/tracks`**: Sets the active audio or subtitle track for an instance. Expects `type` ('audio' or 'subtitle') and `trackId`.
+- **GET `/api/shares`**: Lists the names of the configured media shares.
+- **GET `/api/shares/{share}`**: Retrieves the content (files and directories) of the root of a specific share.
+- **GET `/api/shares/{share}/{path:path}`**: Retrieves the content of a specific path within a share.
+- **GET `/api/thumbnails/{thumbnail_id}`**: Serves the thumbnail image (JPEG) for the given ID. The ID should be the filename without the `.jpg` extension.
+
+## Setup and Running
+
+1.  **Prerequisites**:
+    *   Python 3.10+
+    *   MPV player installed and accessible in your system's PATH.
+    *   FFmpeg installed and accessible in your system's PATH (for thumbnail generation, although `thumbnails.py` itself might use Pillow for manipulation after FFmpeg extraction).
+    *   `uv` (Python packaging tool, install via `pip install uv`).
+
+2.  **Installation**:
+    Navigate to the `mpv-remote-server` directory:
+    ```bash
+    cd mpv-remote-server
+    ```
+    Install dependencies from `pyproject.toml` using `uv`:
+    ```bash
+    uv pip install .
+    ```
+    *(Optional: To generate a `requirements.txt` for other purposes after installation, you can run `uv pip freeze > requirements.txt`)*
+
+3.  **Configuration**:
+    Edit `config.py` to set up your media shares and other settings. The configuration is managed by `pydantic-settings` and can also be set via environment variables (prefixed with `MPV_REMOTE_`) or a `.env` file.
+    Example `config.py` structure:
+    ```python
+    from pathlib import Path
+    from pydantic_settings import BaseSettings, SettingsConfigDict
+
+    class Settings(BaseSettings):
+        media_extensions: set[str] = {".mp4", ".mkv", ".avi"} # Customize your media file extensions
+        thumbnails_dir: Path = Path.cwd() / "thumbnails"    # Directory to store thumbnails
+        cache_file: Path = Path.cwd() / "media-cache.json" # File for media cache
+        media_shares: dict[str, str] = {
+            "movies": "C:/Path/To/Your/Movies",
+            "tv_shows": "/mnt/user/TV_Shows",
+            # Add more shares as needed
+            # "anime": "E:/Anime"
+        }
+
+        model_config = SettingsConfigDict(
+            env_file=".env",
+            env_prefix="MPV_REMOTE_", # e.g., MPV_REMOTE_MEDIA_SHARES='{"movies": "/path"}'
+        )
+
+    settings = Settings()
+    ```
+
+4.  **Running the server**:
+    To run the server using Uvicorn (as specified in `pyproject.toml`'s `fastapi[standard]` which includes uvicorn):
+    ```bash
+    uv run uvicorn main:app --reload --port 8000
+    ```
+    Or, you can use the `run.py` script:
+    ```bash
+    python run.py
+    ```
+    This will also start the server on `http://localhost:8000`.
+
+    **Note on Port Consistency**: The main project `README.md` refers to the server running on port 3000. This server configuration defaults to port 8000. For consistency, you might want to either update the main `README.md` or change the port here using `uvicorn main:app --reload --port 3000`.
+
+```


### PR DESCRIPTION
This commit addresses the issue of outdated documentation by:

1.  **Updating the main README.md:**
    *   Corrected the server description from Bun.js to Python/FastAPI.
    *   Updated server directory references from `/server` to `/mpv-remote-server`.
    *   Revised server setup and configuration instructions to use `uv` and point to `mpv-remote-server/config.py`.
    *   Standardized the server port to 8000 (as used by `uvicorn` and `run.py`).
    *   Added a "Structure" subsection for the `expo-app` to describe its key directories.
    *   Refined the "Prerequisites" and "Getting Started" sections for clarity and accuracy.

2.  **Creating `mpv-remote-server/README.md`:**
    *   Added a new, comprehensive README for the Python server.
    *   Includes an overview, key features, project structure, detailed API endpoint descriptions, and setup/run instructions using `uv`.

These changes ensure that the documentation accurately reflects the project's current architecture and provides clear guidance for you and other developers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the main README to reflect the switch from a Bun.js server to a Python/FastAPI backend, with revised setup and configuration instructions.
  - Clarified prerequisites and provided detailed directory structure for both the backend and mobile app.
  - Added a comprehensive README for the backend server, outlining its features, setup steps, API endpoints, and configuration examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->